### PR TITLE
SearchUserPresenter内のmodelの型を修正

### DIFF
--- a/andfactory-iOS-kadai/SearchUser/Presenter/SearchUserPresenter.swift
+++ b/andfactory-iOS-kadai/SearchUser/Presenter/SearchUserPresenter.swift
@@ -25,9 +25,9 @@ final class SearchUserPresenter {
     private var users: [User] = []
 
     private weak var view: SearchUserPresenterOutput!
-    private var model: SearchUserModel
+    private var model: SearchUserModelInput
 
-    init(view: SearchUserPresenterOutput, model: SearchUserModel) {
+    init(view: SearchUserPresenterOutput, model: SearchUserModelInput) {
         self.view = view
         self.model = model
     }


### PR DESCRIPTION
## やったこと
- SearchUserPresenter内のModelの型がprotocolの指定になっていなかったため、protocolの型を指定するように修正